### PR TITLE
[Serializer] Use correct property types in example

### DIFF
--- a/routing.rst
+++ b/routing.rst
@@ -90,6 +90,7 @@ do so, create a :doc:`controller class </controller>` like the following:
         namespace App\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class BlogController extends AbstractController

--- a/routing.rst
+++ b/routing.rst
@@ -70,6 +70,7 @@ do so, create a :doc:`controller class </controller>` like the following:
         namespace App\Controller;
 
         use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class BlogController extends AbstractController


### PR DESCRIPTION
In the [Selecting Specific Attributes](https://symfony.com/doc/current/components/serializer.html#selecting-specific-attributes) section, there is a type mismatch in the example `User` class. 
